### PR TITLE
Override assert macro

### DIFF
--- a/docs/src/tutorial/arbitrary-variables/check_rating.expected
+++ b/docs/src/tutorial/arbitrary-variables/check_rating.expected
@@ -1,4 +1,4 @@
-[rating::verification::check_rating.assertion.1] line 38 assertion failed: rating.get() <= 5: SUCCESS
-[rating::verification::check_rating.assertion.2] line 39 assertion failed: Rating::from(rating.get()).is_some(): SUCCESS
+[rating::verification::check_rating.assertion.1] line 38 assertion: rating.get() <= 5: SUCCESS
+[rating::verification::check_rating.assertion.2] line 39 assertion: Rating::from(rating.get()).is_some(): SUCCESS
 VERIFICATION SUCCESSFUL
 

--- a/docs/src/tutorial/arbitrary-variables/safe_update.expected
+++ b/docs/src/tutorial/arbitrary-variables/safe_update.expected
@@ -1,4 +1,4 @@
-[inventory::verification::safe_update.assertion.1] line 38 NonZeroU32 is internally a u32 but it should never be 0.: SUCCESS
-[inventory::verification::safe_update.assertion.2] line 42 assertion failed: inventory.get(&id).unwrap() == quantity: SUCCESS
+[inventory::verification::safe_update.assertion.1] line 38 assertion: "NonZeroU32 is internally a u32 but it should never be 0.": SUCCESS
+[inventory::verification::safe_update.assertion.2] line 42 assertion: inventory.get(&id).unwrap() == quantity: SUCCESS
 VERIFICATION SUCCESSFUL
 

--- a/docs/src/tutorial/arbitrary-variables/unsafe_update.expected
+++ b/docs/src/tutorial/arbitrary-variables/unsafe_update.expected
@@ -1,3 +1,3 @@
-[inventory::verification::unsafe_update.assertion.1] line 61 assertion failed: inventory.get(&id).unwrap() == quantity: SUCCESS
+[inventory::verification::unsafe_update.assertion.1] line 61 assertion: inventory.get(&id).unwrap() == quantity: SUCCESS
 called `Option::unwrap()` on a `None` value: FAILURE
 VERIFICATION FAILED

--- a/docs/src/tutorial/kani-first-steps/verify_failure.expected
+++ b/docs/src/tutorial/kani-first-steps/verify_failure.expected
@@ -1,1 +1,1 @@
-[final_form::estimate_size.assertion.1] line 6 assertion failed: x < 4096: FAILURE
+[final_form::estimate_size.assertion.1] line 6 assertion: x < 4096: FAILURE

--- a/docs/src/tutorial/kani-first-steps/verify_success.expected
+++ b/docs/src/tutorial/kani-first-steps/verify_success.expected
@@ -1,2 +1,2 @@
-[final_form::estimate_size.assertion.1] line 6 assertion failed: x < 4096:
-[final_form::verify_success.assertion.1] line 58 assertion failed: y < 10:
+[final_form::estimate_size.assertion.1] line 6 assertion: x < 4096:
+[final_form::verify_success.assertion.1] line 58 assertion: y < 10:

--- a/library/kani/src/lib.rs
+++ b/library/kani/src/lib.rs
@@ -36,6 +36,19 @@ pub use invariant::Invariant;
 #[rustc_diagnostic_item = "KaniAssume"]
 pub fn assume(_cond: bool) {}
 
+/// Creates an assertion of the specified condition and message.
+///
+/// # Example:
+///
+/// ```rust
+/// let x: bool = kani::any();
+/// let y = !x;
+/// kani::assert(x || y, "ORing a boolean variable with its negation must be true")
+/// ```
+#[inline(never)]
+#[rustc_diagnostic_item = "KaniAssert"]
+pub fn assert(_cond: bool, _msg: &'static str) {}
+
 /// This creates an symbolic *valid* value of type `T`. You can assign the return value of this
 /// function to a variable that you want to make symbolic.
 ///

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -11,3 +11,33 @@
 
 // re-export all std symbols
 pub use std::*;
+
+/// This assert macro calls kani's assert function passing it down the condition
+/// as well as a message that will be used when reporting the assertion result.
+///
+/// For the first form that does not involve a message, the macro will generate the following message:
+/// assertion "cond"
+/// where `cond` is the stringified condition. For example, for
+/// ```rust
+/// assert!(1 + 1 == 2);
+/// ```
+/// the message will be:
+/// assertion: 1 + 1 == 2
+///
+/// For the second form that involves a custom message possibly with arguments,
+/// the macro will generate a message that is a concat of the custom message
+/// along with all the arguments. For example, for
+/// ```rust
+/// assert!(a + b == c, "The sum of {} and {} is {}", a, b, c);
+/// ```
+/// the assert message will be:
+/// assertion "The sum of {} and {} is {}", 1, 1, 2
+#[macro_export]
+macro_rules! assert {
+    ($cond:expr $(,)?) => {
+        kani::assert($cond, concat!("assertion: ", stringify!($cond)));
+    };
+    ($cond:expr, $($arg:tt)+) => {
+        kani::assert($cond, concat!("assertion: ", stringify!($($arg)+)));
+    };
+}

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/statement.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/statement.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use super::typ::TypeExt;
 use super::typ::FN_RETURN_VOID_VAR_NAME;
+use crate::utils;
 use crate::{GotocCtx, VtableCtx};
-use cbmc::goto_program::{BuiltinFn, Expr, ExprValue, Location, Stmt, Type};
+use cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Type};
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir;
 use rustc_middle::mir::{
@@ -465,7 +466,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // CBMC requires that the argument to the assertion must be a string constant.
         // If there is one in the MIR, use it; otherwise, explain that we can't.
         assert!(!fargs.is_empty(), "Panic requires a string message");
-        let msg = extract_const_message(&fargs[0]).unwrap_or(String::from(
+        let msg = utils::extract_const_message(&fargs[0]).unwrap_or(String::from(
             "This is a placeholder message; Kani doesn't support message formatted at runtime",
         ));
 
@@ -604,24 +605,5 @@ impl<'tcx> GotocCtx<'tcx> {
             | StatementKind::Coverage { .. } => Stmt::skip(Location::none()),
         }
         .with_location(self.codegen_span(&stmt.source_info.span))
-    }
-}
-
-/// Tries to extract a string message from an `Expr`.
-/// If the expression represents a pointer to a string constant, this will return the string
-/// constant. Otherwise, return `None`.
-fn extract_const_message(arg: &Expr) -> Option<String> {
-    match arg.value() {
-        ExprValue::Struct { values } => match &values[0].value() {
-            ExprValue::AddressOf(address) => match address.value() {
-                ExprValue::Index { array, .. } => match array.value() {
-                    ExprValue::StringConstant { s } => Some(s.to_string()),
-                    _ => None,
-                },
-                _ => None,
-            },
-            _ => None,
-        },
-        _ => None,
     }
 }

--- a/src/kani-compiler/rustc_codegen_kani/src/overrides/hooks.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/overrides/hooks.rs
@@ -8,7 +8,7 @@
 //! It would be too nasty if we spread around these sort of undocumented hooks in place, so
 //! this module addresses this issue.
 
-use crate::utils::instance_name_starts_with;
+use crate::utils;
 use crate::GotocCtx;
 use cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Symbol, Type};
 use cbmc::NO_PRETTY_NAME;
@@ -76,7 +76,7 @@ impl<'tcx> GotocHook<'tcx> for ExpectFail {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
         // Deprecate old __VERIFIER notation that doesn't respect rust naming conventions.
         // Complete removal is tracked here: https://github.com/model-checking/kani/issues/599
-        if instance_name_starts_with(tcx, instance, "__VERIFIER_expect_fail") {
+        if utils::instance_name_starts_with(tcx, instance, "__VERIFIER_expect_fail") {
             warn!(
                 "The function __VERIFIER_expect_fail is deprecated. Use kani::expect_fail instead"
             );
@@ -115,7 +115,7 @@ impl<'tcx> GotocHook<'tcx> for Assume {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
         // Deprecate old __VERIFIER notation that doesn't respect rust naming conventions.
         // Complete removal is tracked here: https://github.com/model-checking/kani/issues/599
-        if instance_name_starts_with(tcx, instance, "__VERIFIER_assume") {
+        if utils::instance_name_starts_with(tcx, instance, "__VERIFIER_assume") {
             warn!("The function __VERIFIER_assume is deprecated. Use kani::assume instead");
             return true;
         }
@@ -146,13 +146,51 @@ impl<'tcx> GotocHook<'tcx> for Assume {
     }
 }
 
+struct Assert;
+impl<'tcx> GotocHook<'tcx> for Assert {
+    fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
+        matches_function(tcx, instance, "KaniAssert")
+    }
+
+    fn handle(
+        &self,
+        tcx: &mut GotocCtx<'tcx>,
+        _instance: Instance<'tcx>,
+        mut fargs: Vec<Expr>,
+        _assign_to: Option<Place<'tcx>>,
+        target: Option<BasicBlock>,
+        span: Option<Span>,
+    ) -> Stmt {
+        assert_eq!(fargs.len(), 2);
+        let cond = fargs.remove(0).cast_to(Type::bool());
+        let msg = fargs.remove(0);
+        let msg = utils::extract_const_message(&msg).unwrap();
+        let target = target.unwrap();
+        let loc = tcx.codegen_span_option(span);
+        let caller_loc = tcx.codegen_caller_span(&span);
+
+        // Since `cond` might have side effects, assign it to a temporary
+        // variable so that it's evaluated once, then assert and assume it
+        let tmp = tcx.gen_temp_variable(cond.typ().clone(), loc.clone()).to_expr();
+        Stmt::block(
+            vec![
+                Stmt::decl(tmp.clone(), Some(cond), loc.clone()),
+                Stmt::assert(tmp.clone(), &msg, caller_loc.clone()),
+                Stmt::assume(tmp, loc.clone()),
+                Stmt::goto(tcx.current_fn().find_label(&target), loc.clone()),
+            ],
+            loc,
+        )
+    }
+}
+
 struct Nondet;
 
 impl<'tcx> GotocHook<'tcx> for Nondet {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
         // Deprecate old __nondet since it doesn't match rust naming conventions.
         // Complete removal is tracked here: https://github.com/model-checking/kani/issues/599
-        if instance_name_starts_with(tcx, instance, "__nondet") {
+        if utils::instance_name_starts_with(tcx, instance, "__nondet") {
             warn!("The function __nondet is deprecated. Use kani::any instead");
             return true;
         }
@@ -648,6 +686,7 @@ pub fn fn_hooks<'tcx>() -> GotocHooks<'tcx> {
         hooks: vec![
             Rc::new(Panic), //Must go first, so it overrides Nevers
             Rc::new(Assume),
+            Rc::new(Assert),
             Rc::new(ExpectFail),
             Rc::new(Intrinsic),
             Rc::new(MemReplace),

--- a/tests/cargo-kani/dependencies/check_dummy.expected
+++ b/tests/cargo-kani/dependencies/check_dummy.expected
@@ -1,1 +1,1 @@
-[check_dummy.assertion.1] line 8 assertion failed: x > 2: SUCCESS
+[check_dummy.assertion.1] line 8 assertion: x > 2: SUCCESS

--- a/tests/cargo-kani/simple-config-toml/test_one_plus_two.expected
+++ b/tests/cargo-kani/simple-config-toml/test_one_plus_two.expected
@@ -1,1 +1,1 @@
-[pair::kani_tests::test_one_plus_two.assertion.1] line 31 assertion failed: p.sum() == 3: SUCCESS
+[pair::kani_tests::test_one_plus_two.assertion.1] line 31 assertion: p.sum() == 3: SUCCESS

--- a/tests/cargo-kani/simple-config-toml/test_sum.expected
+++ b/tests/cargo-kani/simple-config-toml/test_sum.expected
@@ -1,1 +1,1 @@
-[kani_tests::test_sum.assertion.1] line 24 assertion failed: p.sum() == a.wrapping_add(b): SUCCESS
+[kani_tests::test_sum.assertion.1] line 24 assertion: p.sum() == a.wrapping_add(b): SUCCESS

--- a/tests/cargo-kani/simple-lib/test_one_plus_two.expected
+++ b/tests/cargo-kani/simple-lib/test_one_plus_two.expected
@@ -1,1 +1,1 @@
-[pair::kani_tests::test_one_plus_two.assertion.1] line 31 assertion failed: p.sum() == 3: SUCCESS
+[pair::kani_tests::test_one_plus_two.assertion.1] line 31 assertion: p.sum() == 3: SUCCESS

--- a/tests/cargo-kani/simple-lib/test_sum.expected
+++ b/tests/cargo-kani/simple-lib/test_sum.expected
@@ -1,1 +1,1 @@
-[kani_tests::test_sum.assertion.1] line 24 assertion failed: p.sum() == a.wrapping_add(b): SUCCESS
+[kani_tests::test_sum.assertion.1] line 24 assertion: p.sum() == a.wrapping_add(b): SUCCESS

--- a/tests/cargo-kani/simple-main/main.expected
+++ b/tests/cargo-kani/simple-main/main.expected
@@ -1,2 +1,2 @@
-[main.assertion.1] line 4 assertion failed: 1 == 2: FAILURE
+[main.assertion.1] line 4 assertion: 1 == 2: FAILURE
 VERIFICATION FAILED

--- a/tests/cargo-kani/simple-proof-annotation/main.expected
+++ b/tests/cargo-kani/simple-proof-annotation/main.expected
@@ -1,1 +1,1 @@
-line 5 assertion failed: 1 == 2: FAILURE
+line 5 assertion: 1 == 2: FAILURE

--- a/tests/expected/allocation/expected
+++ b/tests/expected/allocation/expected
@@ -1,2 +1,2 @@
-line 8 assertion failed: foo() == None: SUCCESS
-line 11 assertion failed: foo() == y: SUCCESS
+line 8 assertion: foo() == None: SUCCESS
+line 11 assertion: foo() == y: SUCCESS

--- a/tests/expected/array/expected
+++ b/tests/expected/array/expected
@@ -3,7 +3,7 @@ array 'y'.0 upper bound in y.0[var_12]: SUCCESS
 array 'y'.0 upper bound in y.0[var_16]: FAILURE
 array 'x'.0 upper bound in x.0[var_3]: SUCCESS
 array 'x'.0 upper bound in x.0[var_5]: SUCCESS
-line 12 assertion failed: y[0] == 1: SUCCESS
-line 13 assertion failed: y[1] == 2: SUCCESS
+line 12 assertion: y[0] == 1: SUCCESS
+line 13 assertion: y[1] == 2: SUCCESS
 line 14 index out of bounds: the length is move _17 but the index is _16: FAILURE
-line 14 assertion failed: y[z] == 3: FAILURE
+line 14 assertion: y[z] == 3: FAILURE

--- a/tests/expected/assert-location/assert-false/expected
+++ b/tests/expected/assert-location/assert-false/expected
@@ -1,4 +1,4 @@
-line 12 assertion failed: false: FAILURE
-line 17 This is a placeholder message; Kani doesn't support message formatted at runtime: FAILURE
-line 21 Fail with custom static message: FAILURE
+line 12 assertion: false: FAILURE
+line 17 assertion: "{}", s: FAILURE
+line 21 assertion: "Fail with custom static message": FAILURE
 

--- a/tests/expected/assert-location/debug-assert/expected
+++ b/tests/expected/assert-location/debug-assert/expected
@@ -1,3 +1,3 @@
 line 6 This should fail and stop the execution: FAILURE
-line 7 This should be unreachable: SUCCESS
+line 7 assertion: "This should be unreachable": SUCCESS
 

--- a/tests/expected/binop/expected
+++ b/tests/expected/binop/expected
@@ -1,42 +1,42 @@
 line 4 attempt to compute `move _8 + move _9`, which would overflow: SUCCESS
-line 4 assertion failed: a + b == correct: SUCCESS
+line 4 assertion: a + b == correct: SUCCESS
 line 5 attempt to compute `move _15 + move _16`, which would overflow: SUCCESS
-line 5 assertion failed: a + b == wrong: FAILURE
+line 5 assertion: a + b == wrong: FAILURE
 line 9 attempt to compute `move _8 - move _9`, which would overflow: SUCCESS
-line 9 assertion failed: a - b == correct: SUCCESS
+line 9 assertion: a - b == correct: SUCCESS
 line 10 attempt to compute `move _15 - move _16`, which would overflow: SUCCESS
-line 10 assertion failed: a - b == wrong: FAILURE
+line 10 assertion: a - b == wrong: FAILURE
 line 14 attempt to compute `move _8 * move _9`, which would overflow: SUCCESS
-line 14 assertion failed: a * b == correct: SUCCESS
+line 14 assertion: a * b == correct: SUCCESS
 line 15 attempt to compute `move _15 * move _16`, which would overflow: SUCCESS
-line 15 assertion failed: a * b == wrong: FAILURE
+line 15 assertion: a * b == wrong: FAILURE
 line 19 attempt to divide `_8` by zero: SUCCESS
 line 19 attempt to compute `_8 / _9`, which would overflow: SUCCESS
-line 19 assertion failed: a / b == correct: SUCCESS
+line 19 assertion: a / b == correct: SUCCESS
 line 20 attempt to divide `_18` by zero: SUCCESS
 line 20 attempt to compute `_18 / _19`, which would overflow: SUCCESS
-line 20 assertion failed: a / b == wrong: FAILURE
+line 20 assertion: a / b == wrong: FAILURE
 line 24 attempt to calculate the remainder of `_8` with a divisor of zero: SUCCESS
 line 24 attempt to compute the remainder of `_8 % _9`, which would overflow: SUCCESS
-line 24 assertion failed: a % b == correct: SUCCESS
+line 24 assertion: a % b == correct: SUCCESS
 line 25 attempt to calculate the remainder of `_18` with a divisor of zero: SUCCESS
 line 25 attempt to compute the remainder of `_18 % _19`, which would overflow: SUCCESS
-line 25 assertion failed: a % b == wrong: FAILURE
+line 25 assertion: a % b == wrong: FAILURE
 line 29 attempt to shift left by `move _9`, which would overflow: SUCCESS
-line 29 assertion failed: a << b == correct: SUCCESS
+line 29 assertion: a << b == correct: SUCCESS
 line 30 attempt to shift left by `move _16`, which would overflow: SUCCESS
-line 30 assertion failed: a << b == wrong: FAILURE
+line 30 assertion: a << b == wrong: FAILURE
 line 34 attempt to shift right by `move _9`, which would overflow: SUCCESS
-line 34 assertion failed: a >> b == correct: SUCCESS
+line 34 assertion: a >> b == correct: SUCCESS
 line 35 attempt to shift right by `move _16`, which would overflow: SUCCESS
-line 35 assertion failed: a >> b == wrong: FAILURE
+line 35 assertion: a >> b == wrong: FAILURE
 line 39 attempt to shift right by `move _9`, which would overflow: SUCCESS
-line 39 assertion failed: a >> b == correct: SUCCESS
+line 39 assertion: a >> b == correct: SUCCESS
 line 40 attempt to shift right by `move _16`, which would overflow: SUCCESS
-line 40 assertion failed: a >> b == wrong: FAILURE
-line 44 assertion failed: a & b == correct: SUCCESS
-line 45 assertion failed: a & b == wrong: FAILURE
-line 49 assertion failed: a | b == correct: SUCCESS
-line 50 assertion failed: a | b == wrong: FAILURE
-line 54 assertion failed: a ^ b == correct: SUCCESS
-line 55 assertion failed: a ^ b == wrong: FAILURE
+line 40 assertion: a >> b == wrong: FAILURE
+line 44 assertion: a & b == correct: SUCCESS
+line 45 assertion: a & b == wrong: FAILURE
+line 49 assertion: a | b == correct: SUCCESS
+line 50 assertion: a | b == wrong: FAILURE
+line 54 assertion: a ^ b == correct: SUCCESS
+line 55 assertion: a ^ b == wrong: FAILURE

--- a/tests/expected/closure/expected
+++ b/tests/expected/closure/expected
@@ -2,5 +2,5 @@ line 18 attempt to compute `move _8 + move _9`, which would overflow: SUCCESS
 line 18 attempt to compute `move _5 + move _6`, which would overflow: SUCCESS
 line 18 attempt to compute `(*((*_1).0: &mut i32)) + move _4`, which would overflow: SUCCESS
 line 23 attempt to compute `move _18 + const 12_i32`, which would overflow: SUCCESS
-line 23 assertion failed: original_num + 12 == num: SUCCESS
+line 23 assertion: original_num + 12 == num: SUCCESS
 line 23 arithmetic overflow on signed + in var_18 + 12: SUCCESS

--- a/tests/expected/closure2/expected
+++ b/tests/expected/closure2/expected
@@ -1,4 +1,4 @@
 line 5 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
 line 7 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
-line 8 assertion failed: z == 102: SUCCESS
-line 9 assertion failed: g(z) == 206: SUCCESS
+line 8 assertion: z == 102: SUCCESS
+line 9 assertion: g(z) == 206: SUCCESS

--- a/tests/expected/closure3/expected
+++ b/tests/expected/closure3/expected
@@ -1,3 +1,3 @@
 line 14 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
 line 15 attempt to compute `move _11 + const 10_i64`, which would overflow: SUCCESS
-line 15 assertion failed: num + 10 == y: SUCCESS
+line 15 assertion: num + 10 == y: SUCCESS

--- a/tests/expected/comp/expected
+++ b/tests/expected/comp/expected
@@ -1,11 +1,11 @@
 line 5 attempt to compute `move _6 + move _7`, which would overflow: SUCCESS
 line 5 attempt to compute `move _10 + move _11`, which would overflow: SUCCESS
-line 5 assertion failed: a + b == b + a: SUCCESS
+line 5 assertion: a + b == b + a: SUCCESS
 line 6 attempt to compute `move _16 + move _17`, which would overflow: SUCCESS
 line 6 attempt to compute `move _21 + move _22`, which would overflow: SUCCESS
 line 6 attempt to compute `move _20 + const 1_i32`, which would overflow: SUCCESS
-line 6 assertion failed: a + b != a + b + 1: SUCCESS
+line 6 assertion: a + b != a + b + 1: SUCCESS
 line 11 attempt to compute `move _6 + move _7`, which would overflow: SUCCESS
-line 11 assertion failed: a + b > a: SUCCESS
+line 11 assertion: a + b > a: SUCCESS
 line 12 attempt to compute `move _13 - move _14`, which would overflow: SUCCESS
-line 12 assertion failed: a - b < a: SUCCESS
+line 12 assertion: a - b < a: SUCCESS

--- a/tests/expected/copy/expected
+++ b/tests/expected/copy/expected
@@ -1,3 +1,3 @@
 memmove source region readable: SUCCESS
 memmove destination region writeable: SUCCESS
-assertion failed: *dst == expected_val: SUCCESS
+assertion: *dst == expected_val: SUCCESS

--- a/tests/expected/dynamic-error-trait/expected
+++ b/tests/expected/dynamic-error-trait/expected
@@ -1,2 +1,2 @@
-assertion failed: mm.size == 2: SUCCESS
-assertion failed: mm.size == 3: FAILURE
+assertion: mm.size == 2: SUCCESS
+assertion: mm.size == 3: FAILURE

--- a/tests/expected/dynamic-trait-static-dispatch/expected
+++ b/tests/expected/dynamic-trait-static-dispatch/expected
@@ -1,2 +1,2 @@
-line 25 assertion failed: bar.a() == 3: SUCCESS
-line 26 assertion failed: bar.b() == 5: SUCCESS
+line 25 assertion: bar.a() == 3: SUCCESS
+line 26 assertion: bar.b() == 5: SUCCESS

--- a/tests/expected/dynamic-trait/expected
+++ b/tests/expected/dynamic-trait/expected
@@ -4,13 +4,13 @@ line 26 attempt to compute `move _3 * move _7`, which would overflow: SUCCESS
 line 32 attempt to compute `move _2 * move _3`, which would overflow: SUCCESS
 line 35 attempt to compute `move _4 * move _5`, which would overflow: SUCCESS
 line 35 attempt to compute `move _3 * move _7`, which would overflow: SUCCESS
-line 52 assertion failed: rec.vol(3) == 150: SUCCESS
-line 53 assertion failed: impl_area(rec.clone()) == 50: SUCCESS
-line 56 assertion failed: vol == 100: SUCCESS
-line 59 assertion failed: square.vol(3) == 27: SUCCESS
-line 60 assertion failed: do_vol(&square, 2) == 18: SUCCESS
-line 61 assertion failed: impl_area(square.clone()) == 9: SUCCESS
-line 63 assertion failed: !square.compare_area(&square): SUCCESS
-line 64 assertion failed: !square.compare_area(&rec): SUCCESS
-line 65 assertion failed: rec.compare_area(&square): SUCCESS
-line 66 assertion failed: !rec.compare_area(&rec): SUCCESS
+line 52 assertion: rec.vol(3) == 150: SUCCESS
+line 53 assertion: impl_area(rec.clone()) == 50: SUCCESS
+line 56 assertion: vol == 100: SUCCESS
+line 59 assertion: square.vol(3) == 27: SUCCESS
+line 60 assertion: do_vol(&square, 2) == 18: SUCCESS
+line 61 assertion: impl_area(square.clone()) == 9: SUCCESS
+line 63 assertion: !square.compare_area(&square): SUCCESS
+line 64 assertion: !square.compare_area(&rec): SUCCESS
+line 65 assertion: rec.compare_area(&square): SUCCESS
+line 66 assertion: !rec.compare_area(&rec): SUCCESS

--- a/tests/expected/enum/expected
+++ b/tests/expected/enum/expected
@@ -1,7 +1,7 @@
 line 18 unreachable code: SUCCESS
-line 19 assertion failed: x == 10: SUCCESS
-line 20 assertion failed: false: SUCCESS
+line 19 assertion: x == 10: SUCCESS
+line 20 assertion: false: SUCCESS
 line 22 unreachable code: SUCCESS
-line 23 assertion failed: false: SUCCESS
-line 25 assertion failed: x == 30 && y == 60.0: SUCCESS
-line 26 assertion failed: x == 31: FAILURE
+line 23 assertion: false: SUCCESS
+line 25 assertion: x == 30 && y == 60.0: SUCCESS
+line 26 assertion: x == 31: FAILURE

--- a/tests/expected/float-nan/expected
+++ b/tests/expected/float-nan/expected
@@ -1,5 +1,5 @@
-line 12 assertion failed: 1.0 / f != 0.0 / f: SUCCESS
-line 14 assertion failed: !(1.0 / f == 0.0 / f): SUCCESS
-line 16 assertion failed: 1.0 / f == 0.0 / f: FAILURE
-line 18 assertion failed: 0.0 / f == 0.0 / f: FAILURE
-line 20 assertion failed: 0.0 / f != 0.0 / f: SUCCESS
+line 12 assertion: 1.0 / f != 0.0 / f: SUCCESS
+line 14 assertion: !(1.0 / f == 0.0 / f): SUCCESS
+line 16 assertion: 1.0 / f == 0.0 / f: FAILURE
+line 18 assertion: 0.0 / f == 0.0 / f: FAILURE
+line 20 assertion: 0.0 / f != 0.0 / f: SUCCESS

--- a/tests/expected/generics/expected
+++ b/tests/expected/generics/expected
@@ -1,2 +1,2 @@
-line 21 assertion failed: x == y.data: SUCCESS
-line 22 assertion failed: z == w.data: SUCCESS
+line 21 assertion: x == y.data: SUCCESS
+line 22 assertion: z == w.data: SUCCESS

--- a/tests/expected/iterator/expected
+++ b/tests/expected/iterator/expected
@@ -1,3 +1,3 @@
 line 5 unreachable code: SUCCESS
 line 6 attempt to compute `_1 * move _10`, which would overflow: SUCCESS
-line 8 assertion failed: z == 6: SUCCESS
+line 8 assertion: z == 6: SUCCESS

--- a/tests/expected/niche/expected
+++ b/tests/expected/niche/expected
@@ -1,5 +1,5 @@
-line 22 assertion failed: false: SUCCESS
+line 22 assertion: false: SUCCESS
 line 20 unreachable code: SUCCESS
 line 25 unreachable code: SUCCESS
-line 26 assertion failed: false: SUCCESS
-line 27 assertion failed: a == *b: SUCCESS
+line 26 assertion: false: SUCCESS
+line 27 assertion: a == *b: SUCCESS

--- a/tests/expected/niche2/expected
+++ b/tests/expected/niche2/expected
@@ -1,4 +1,4 @@
-line 23 assertion failed: false: SUCCESS
-line 27 assertion failed: x == 10: SUCCESS
-line 28 assertion failed: false: SUCCESS
-line 33 assertion failed: false: SUCCESS
+line 23 assertion: false: SUCCESS
+line 27 assertion: x == 10: SUCCESS
+line 28 assertion: false: SUCCESS
+line 33 assertion: false: SUCCESS

--- a/tests/expected/nondet/expected
+++ b/tests/expected/nondet/expected
@@ -2,4 +2,4 @@ line 7 attempt to compute `move _12 * move _13`, which would overflow: SUCCESS
 line 7 attempt to compute `const 2_i32 * move _16`, which would overflow: SUCCESS
 line 7 attempt to compute `move _11 - move _15`, which would overflow: SUCCESS
 line 7 attempt to compute `move _10 + const 1_i32`, which would overflow: SUCCESS
-line 7 assertion failed: x * x - 2 * x + 1 != 4 || (x == -1 || x == 3): SUCCESS
+line 7 assertion: x * x - 2 * x + 1 != 4 || (x == -1 || x == 3): SUCCESS

--- a/tests/expected/references/expected
+++ b/tests/expected/references/expected
@@ -1,1 +1,1 @@
-line 17 assertion failed: z == 2: SUCCESS
+line 17 assertion: z == 2: SUCCESS

--- a/tests/expected/report/unsupported/failure/expected
+++ b/tests/expected/report/unsupported/failure/expected
@@ -1,4 +1,4 @@
-assertion failed: x == 0
-Failed Checks: assertion failed: x == 0
+assertion: x == 0
+Failed Checks: assertion: x == 0
 Failed Checks: InlineAsm is not currently supported by Kani. Please post your example at https://github.com/model-checking/kani/issues/2
 ** WARNING: A Rust construct that is not currently supported by Kani was found to be reachable. Check the results for more details.

--- a/tests/expected/report/unsupported/reachable/expected
+++ b/tests/expected/report/unsupported/reachable/expected
@@ -1,4 +1,4 @@
 UNDETERMINED
-assertion failed: x == 0
+assertion: x == 0"
 Failed Checks: InlineAsm is not currently supported by Kani. Please post your example at https://github.com/model-checking/kani/issues/2
 ** WARNING: A Rust construct that is not currently supported by Kani was found to be reachable. Check the results for more details.

--- a/tests/expected/report/unsupported/unreachable/expected
+++ b/tests/expected/report/unsupported/unreachable/expected
@@ -1,3 +1,3 @@
 SUCCESS
-assertion failed: x == 0
+assertion: x == 0"
 SUCCESSFUL

--- a/tests/expected/slice/expected
+++ b/tests/expected/slice/expected
@@ -1,4 +1,4 @@
-line 15 assertion failed: y.len() == 5: SUCCESS
+line 15 assertion: y.len() == 5: SUCCESS
 line 16 index out of bounds: the length is move _16 but the index is _15: SUCCESS
-line 16 assertion failed: y[1] == 2: SUCCESS
-line 17 assertion failed: z.len() == 3: SUCCESS
+line 16 assertion: y[1] == 2: SUCCESS
+line 17 assertion: z.len() == 3: SUCCESS

--- a/tests/expected/static-mutable-struct/expected
+++ b/tests/expected/static-mutable-struct/expected
@@ -1,12 +1,12 @@
-line 23 assertion failed: foo().x == 12: SUCCESS
-line 25 assertion failed: foo().y == 12: FAILURE
-line 28 assertion failed: foo().x == 14: FAILURE
-line 30 assertion failed: foo().y == 14: SUCCESS
-line 33 assertion failed: foo().x == 1: SUCCESS
-line 35 assertion failed: foo().y == 1: FAILURE
-line 38 assertion failed: foo().x == 2: FAILURE
-line 40 assertion failed: foo().y == 2: SUCCESS
-line 43 assertion failed: foo().x == 1 << 62: SUCCESS
-line 45 assertion failed: foo().x == 1 << 31: FAILURE
-line 47 assertion failed: foo().y == 1 << 31: SUCCESS
+line 23 assertion: foo().x == 12: SUCCESS
+line 25 assertion: foo().y == 12: FAILURE
+line 28 assertion: foo().x == 14: FAILURE
+line 30 assertion: foo().y == 14: SUCCESS
+line 33 assertion: foo().x == 1: SUCCESS
+line 35 assertion: foo().y == 1: FAILURE
+line 38 assertion: foo().x == 2: FAILURE
+line 40 assertion: foo().y == 2: SUCCESS
+line 43 assertion: foo().x == 1 << 62: SUCCESS
+line 45 assertion: foo().x == 1 << 31: FAILURE
+line 47 assertion: foo().y == 1 << 31: SUCCESS
 

--- a/tests/expected/static-mutable/expected
+++ b/tests/expected/static-mutable/expected
@@ -1,4 +1,4 @@
-line 17 assertion failed: 10 == foo(): FAILURE
-line 19 assertion failed: 12 == foo(): SUCCESS
-line 21 assertion failed: 10 == foo(): SUCCESS
-line 22 assertion failed: 12 == foo(): FAILURE
+line 17 assertion: 10 == foo(): FAILURE
+line 19 assertion: 12 == foo(): SUCCESS
+line 21 assertion: 10 == foo(): SUCCESS
+line 22 assertion: 12 == foo(): FAILURE

--- a/tests/expected/static/expected
+++ b/tests/expected/static/expected
@@ -1,2 +1,2 @@
-line 10 assertion failed: 10 == foo(): FAILURE
-line 11 assertion failed: 12 == foo(): SUCCESS
+line 10 assertion: 10 == foo(): FAILURE
+line 11 assertion: 12 == foo(): SUCCESS

--- a/tests/expected/test1/expected
+++ b/tests/expected/test1/expected
@@ -1,5 +1,5 @@
 line 7 attempt to compute `_1 + move _4`, which would overflow: SUCCESS
 line 8 attempt to compute `_2 - const 1_i32`, which would overflow: SUCCESS
-line 12 assertion failed: a == 54: FAILURE
-line 14 assertion failed: a == 55: SUCCESS
-line 16 assertion failed: a >= 55: SUCCESS
+line 12 assertion: a == 54: FAILURE
+line 14 assertion: a == 55: SUCCESS
+line 16 assertion: a >= 55: SUCCESS

--- a/tests/expected/test2/expected
+++ b/tests/expected/test2/expected
@@ -1,5 +1,5 @@
 line 7 attempt to shift right by `const 1_i32`, which would overflow: SUCCESS
 line 8 attempt to compute `_2 + const 1_i32`, which would overflow: SUCCESS
-line 13 assertion failed: i == 3: FAILURE
-line 15 assertion failed: i == 2: SUCCESS
-line 17 assertion failed: i == 2 || i == 3: SUCCESS
+line 13 assertion: i == 3: FAILURE
+line 15 assertion: i == 2: SUCCESS
+line 17 assertion: i == 2 || i == 3: SUCCESS

--- a/tests/expected/test3/expected
+++ b/tests/expected/test3/expected
@@ -1,9 +1,9 @@
 line 9 attempt to compute `_2 - const 1_i32`, which would overflow: SUCCESS
-line 15 assertion failed: a == 10.0 && i == 1: FAILURE
-line 17 assertion failed: a == 9.0 && i == 0: FAILURE
-line 19 assertion failed: a == 9.0 && i == 1: FAILURE
-line 21 assertion failed: a == 10.0 && i == 0: SUCCESS
-line 23 assertion failed: a == 9.0 || i == 0: SUCCESS
-line 25 assertion failed: a == 10.0 || i == 1: SUCCESS
-line 27 assertion failed: a == 9.0 || i == 1: FAILURE
-line 29 assertion failed: a == 10.0 || i == 0: SUCCESS
+line 15 assertion: a == 10.0 && i == 1: FAILURE
+line 17 assertion: a == 9.0 && i == 0: FAILURE
+line 19 assertion: a == 9.0 && i == 1: FAILURE
+line 21 assertion: a == 10.0 && i == 0: SUCCESS
+line 23 assertion: a == 9.0 || i == 0: SUCCESS
+line 25 assertion: a == 10.0 || i == 1: SUCCESS
+line 27 assertion: a == 9.0 || i == 1: FAILURE
+line 29 assertion: a == 10.0 || i == 0: SUCCESS

--- a/tests/expected/test4/expected
+++ b/tests/expected/test4/expected
@@ -1,6 +1,6 @@
 line 8 attempt to compute `_2 + const 1_i32`, which would overflow: SUCCESS
-line 13 assertion failed: i == 3: FAILURE
-line 15 assertion failed: i == 2: SUCCESS
-line 17 assertion failed: i == 2 || i == 3: SUCCESS
+line 13 assertion: i == 3: FAILURE
+line 15 assertion: i == 2: SUCCESS
+line 17 assertion: i == 2 || i == 3: SUCCESS
 line 21 attempt to divide `_3` by zero: SUCCESS
 line 21 attempt to compute `_3 / _4`, which would overflow: SUCCESS

--- a/tests/expected/test5/expected
+++ b/tests/expected/test5/expected
@@ -1,4 +1,4 @@
-line 5 assertion failed: div(4, 2) == 2: SUCCESS
-line 7 assertion failed: div(6, 2) == 2: FAILURE
+line 5 assertion: div(4, 2) == 2: SUCCESS
+line 7 assertion: div(6, 2) == 2: FAILURE
 line 11 attempt to divide `_3` by zero: SUCCESS
 line 11 attempt to compute `_3 / _4`, which would overflow: SUCCESS

--- a/tests/expected/test6/expected
+++ b/tests/expected/test6/expected
@@ -1,2 +1,2 @@
-line 9 assertion failed: add2(1, 1) == 2.0: SUCCESS
-line 11 assertion failed: add2(2, 1) == 2.0: FAILURE
+line 9 assertion: add2(1, 1) == 2.0: SUCCESS
+line 11 assertion: add2(2, 1) == 2.0: FAILURE

--- a/tests/expected/transmute/expected
+++ b/tests/expected/transmute/expected
@@ -1,2 +1,2 @@
-line 5 assertion failed: bitpattern == 0x3F800000: SUCCESS
-line 11 assertion failed: f == 1.0: SUCCESS
+line 5 assertion: bitpattern == 0x3F800000: SUCCESS
+line 11 assertion: f == 1.0: SUCCESS

--- a/tests/expected/vec/expected
+++ b/tests/expected/vec/expected
@@ -12,6 +12,6 @@
 [realloc.precondition_instance.10] line 30 double free: SUCCESS
 [realloc.precondition_instance.11] line 30 free called for new[] object: SUCCESS
 [realloc.precondition_instance.12] line 30 free called for stack-allocated object: SUCCESS
-line 6 assertion failed: x[0] == 10: SUCCESS
-line 8 assertion failed: y == 10: SUCCESS
-line 9 assertion failed: y != 10: FAILURE
+line 6 assertion: x[0] == 10: SUCCESS
+line 8 assertion: y == 10: SUCCESS
+line 9 assertion: y != 10: FAILURE

--- a/tests/expected/vecdq/expected
+++ b/tests/expected/vecdq/expected
@@ -1,6 +1,6 @@
-assertion failed: q.len() == 2: SUCCESS
-assertion failed: q.pop_front().unwrap() == x: SUCCESS
-assertion failed: q.pop_front().unwrap() == y: SUCCESS
+assertion: q.len() == 2: SUCCESS
+assertion: q.pop_front().unwrap() == x: SUCCESS
+assertion: q.pop_front().unwrap() == y: SUCCESS
 max allocation size exceeded: SUCCESS
 max allocation may fail: SUCCESS
 max allocation size exceeded: SUCCESS


### PR DESCRIPTION
### Description of changes: 

Override the `assert` macro via calling a new `kani::assert` function that is implemented in codegen (via a hook).

For assertions without a message (e.g. `assert!(1 + 1 == 2)`), the new version of the assert macro produces an `assertion: <cond>` message as opposed to `assertion failed: <cond>` (i.e., "failed" is dropped).

For assertions with a message, e.g. `assert!(a == b, "a and b have the values {} and {}, respectively", a, b)`, it produces `assertion: "a and b have the values {} and {}, respectively", a, b` instead of the current `This is a placeholder message; Kani doesn't support message formatted at runtime`.

### Resolved issues:

Resolves #189


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Current regressions

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
